### PR TITLE
ci(trunk): use org reusable workflow

### DIFF
--- a/.github/workflows/trunk-check.yml
+++ b/.github/workflows/trunk-check.yml
@@ -1,22 +1,25 @@
 ---
-name: "⭕ Trunk"
+name: Trunk Code Quality
+
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize, reopened]
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+
 concurrency:
-  group: ${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    name: Trunk Code Quality
     permissions:
-      checks: write # For trunk to post annotations
-      contents: read # For repo checkout
-    steps:
-      - name: ✅ Checkout
-        uses: actions/checkout@v5
-      - name: ✨ Trunk Check
-        uses: trunk-io/trunk-action@v1
+      actions: read
+      checks: write
+      contents: read
+    uses: z-shell/.github/.github/workflows/trunk.yml@main
+    with:
+      arguments: --no-progress


### PR DESCRIPTION
## Summary

- Replace the direct Trunk action workflow with the shared org reusable Trunk workflow.
- Remove mutable action references from the caller workflow.
- Add explicit permissions, concurrency, and `arguments: --no-progress`.

Part of z-shell/.github#408.

## Verification

- Compared branch against `main`: one-file workflow-only diff.
- YAML shape reviewed after writing `.github/workflows/trunk-check.yml`.

## Agent handoff

**Status:** Ready for review
**Current state:** PR contains only the Trunk caller migration for `.github/workflows/trunk-check.yml`.
**Blockers:** None known.
**Next steps:** Wait for PR CI; merge if green.