### PR TITLE
ci(workflows): add concurrency group to zsh-n

### DIFF
--- a/.github/workflows/zsh-n.yml
+++ b/.github/workflows/zsh-n.yml
@@ -16,6 +16,10 @@ on:
 
 permissions: read-all
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   zsh-matrix:
     runs-on: ubuntu-latest


### PR DESCRIPTION
ZSH-1 CI modernization (perms/concurrency sweep). zsh-n had `permissions: read-all` but no `concurrency`; adds the standard group. (Clean re-do of #40, which was based on a divergent commit.)