### PR TITLE
fix(plugin): restore state on unload

### DIFF
--- a/lib/compatibility.zsh
+++ b/lib/compatibility.zsh
@@ -5,38 +5,38 @@
 
 case "$OSTYPE" in
   android*)
-    typeset -g OS='android'
+    typeset -g ZFC_OS='android'
     ;;
   darwin*)
-    typeset -g OS='darwin'
+    typeset -g ZFC_OS='darwin'
     ;;
   linux*)
-    typeset -g OS='linux'
+    typeset -g ZFC_OS='linux'
     ;;
   freebsd*)
-    typeset -g OS='freebsd'
+    typeset -g ZFC_OS='freebsd'
     ;;
   netbsd*)
-    typeset -g OS='netbsd'
+    typeset -g ZFC_OS='netbsd'
     ;;
   openbsd*)
-    typeset -g OS='openbsd'
+    typeset -g ZFC_OS='openbsd'
     ;;
   sunos*)
-    typeset -g OS='solaris'
+    typeset -g ZFC_OS='solaris'
     ;;
   msys* | cygwin* | mingw*)
-    typeset -g OS='windows'
+    typeset -g ZFC_OS='windows'
     ;;
   nt | win*)
-    typeset -g OS='windows'
+    typeset -g ZFC_OS='windows'
     ;;
   *)
-    typeset -g OS='unknown'
+    typeset -g ZFC_OS='unknown'
     ;;
 esac
 
-if [[ $OS == 'darwin' ]]; then
+if [[ $ZFC_OS == 'darwin' ]]; then
   # Add completion for keg-only brewed curl on macOS when available.
   if (( $+commands[brew] )); then
     typeset brew_prefix=${HOMEBREW_PREFIX:-${HOMEBREW_REPOSITORY:-$commands[brew]:A:h:h}}
@@ -47,7 +47,7 @@ if [[ $OS == 'darwin' ]]; then
     
     # Only add to fpath if the directory exists
     [[ -d "$brew_prefix/opt/curl/share/zsh/site-functions" ]] && \
-      fpath=($brew_prefix/opt/curl/share/zsh/site-functions $fpath)
+      _zfc_add_fpath "$brew_prefix/opt/curl/share/zsh/site-functions" prepend
     
     unset brew_prefix
   fi

--- a/lib/completion.zsh
+++ b/lib/completion.zsh
@@ -18,7 +18,7 @@ unsetopt FLOW_CONTROL         # Disable start/stop characters in shell editor.
 
 # Enable cache - Some functions, like _apt and _dpkg, are very slow.
 # You can use a cache to proxy the list of results (like the list of available Debian packages)
-typeset cache_dir="${ZI[CACHE_DIR]:-${XDG_CACHE_HOME:-${ZDOTDIR:-$HOME/.cache}}/zi}"
+typeset cache_dir="${ZI[CACHE_DIR]-${XDG_CACHE_HOME:-${ZDOTDIR:-$HOME/.cache}}/zi}"
 if [[ ! -d "$cache_dir" ]]; then
   if ! mkdir -p "$cache_dir" 2>/dev/null; then
     # Fallback to a temporary directory if cache creation fails
@@ -106,7 +106,9 @@ zstyle ':completion:*:history-words' list false
 zstyle ':completion:*:history-words' menu yes
 
 # Environmental Variables
-zstyle ':completion::*:(-command-|export):*' fake-parameters ${${${_comps[(I)-value-*]#*,}%%,*}:#-*-}
+if (( ${+_comps} )); then
+  zstyle ':completion::*:(-command-|export):*' fake-parameters ${${${_comps[(I)-value-*]#*,}%%,*}:#-*-}
+fi
 
 # Complete . and .. special directories
 zstyle ':completion:*' special-dirs true

--- a/lib/state.zsh
+++ b/lib/state.zsh
@@ -1,0 +1,127 @@
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+
+typeset -gA _zfc_original_options _zfc_touched_zstyles _zfc_original_widgets
+typeset -gA _zfc_original_bindings _zfc_original_compctls
+typeset -ga _zfc_added_fpath _zfc_original_zstyles
+typeset -g _zfc_original_plugin_dir _zfc_original_plugin_dir_set
+typeset -g _zfc_original_os _zfc_original_os_set
+
+_zfc_capture_state() {
+  local option widget map key command
+
+  _zfc_original_plugin_dir_set=${+Plugins[ZF_COMPLETIONS]}
+  _zfc_original_plugin_dir=${Plugins[ZF_COMPLETIONS]-}
+  _zfc_original_os_set=${+ZFC_OS}
+  _zfc_original_os=${ZFC_OS-}
+  _zfc_original_zstyles=( "${(@f)$(builtin zstyle -L)}" )
+
+  for option in COMPLETE_IN_WORD ALWAYS_TO_END PATH_DIRS AUTO_MENU AUTO_LIST \
+    AUTO_PARAM_SLASH HIST_EXPIRE_DUPS_FIRST EXTENDED_GLOB MENU_COMPLETE FLOW_CONTROL; do
+    if [[ -o "$option" ]]; then
+      _zfc_original_options[$option]=setopt
+    else
+      _zfc_original_options[$option]=unsetopt
+    fi
+  done
+
+  for widget in .complete_menu .expand-or-complete-with-dots; do
+    _zfc_original_widgets[$widget]=$(zle -l -L "$widget" 2>/dev/null) ||
+      _zfc_original_widgets[$widget]=''
+  done
+
+  for map in emacs viins vicmd; do
+    key="${map}"$'\x1f''^I'
+    _zfc_original_bindings[$key]=$(bindkey -M "$map" '^I' 2>/dev/null) ||
+      _zfc_original_bindings[$key]=''
+  done
+
+  for command in man ftp lftp ncftp ssh w3m lynx links elinks nc telnet rlogin host finger; do
+    _zfc_original_compctls[$command]=$(builtin compctl -L "$command" 2>/dev/null) ||
+      _zfc_original_compctls[$command]=''
+  done
+}
+
+_zfc_add_fpath() {
+  local path=$1 position=${2:-append}
+
+  (( ${fpath[(Ie)$path]} )) && return 0
+  _zfc_added_fpath+=( "$path" )
+  if [[ $position == prepend ]]; then
+    fpath=( "$path" "${fpath[@]}" )
+  else
+    fpath+=( "$path" )
+  fi
+}
+
+_zfc_zstyle() {
+  local context style key
+
+  if [[ $1 == -e ]]; then
+    context=$2
+    style=$3
+  else
+    context=$1
+    style=$2
+  fi
+  key="${context}"$'\x1f'"${style}"
+  _zfc_touched_zstyles[$key]=1
+  builtin zstyle "$@"
+}
+
+zsh-fancy-completions_plugin_unload() {
+  local key context style snapshot path option widget map binding command
+
+  for key in "${(@k)_zfc_touched_zstyles}"; do
+    context=${key%%$'\x1f'*}
+    style=${key#*$'\x1f'}
+    builtin zstyle -d "$context" "$style"
+  done
+  for snapshot in "${_zfc_original_zstyles[@]}"; do
+    eval "$snapshot"
+  done
+
+  for command snapshot in "${(@kv)_zfc_original_compctls}"; do
+    builtin compctl + "$command" 2>/dev/null
+    [[ -z $snapshot ]] || eval "$snapshot"
+  done
+
+  for key binding in "${(@kv)_zfc_original_bindings}"; do
+    map=${key%%$'\x1f'*}
+    key=${key#*$'\x1f'}
+    bindkey -M "$map" -r "$key" 2>/dev/null
+    [[ -z $binding ]] || eval "bindkey -M ${(q)map} $binding"
+  done
+
+  for widget snapshot in "${(@kv)_zfc_original_widgets}"; do
+    zle -D "$widget" 2>/dev/null || true
+    [[ -z $snapshot ]] || eval "$snapshot"
+  done
+
+  for option snapshot in "${(@kv)_zfc_original_options}"; do
+    "$snapshot" "$option"
+  done
+
+  for path in "${_zfc_added_fpath[@]}"; do
+    fpath=( "${fpath[@]:#$path}" )
+  done
+
+  if (( _zfc_original_plugin_dir_set )); then
+    Plugins[ZF_COMPLETIONS]=$_zfc_original_plugin_dir
+  else
+    unset 'Plugins[ZF_COMPLETIONS]'
+  fi
+  if (( _zfc_original_os_set )); then
+    ZFC_OS=$_zfc_original_os
+  else
+    unset ZFC_OS
+  fi
+
+  unfunction _zfc_capture_state _zfc_add_fpath _zfc_zstyle
+  unset _zfc_original_options _zfc_touched_zstyles _zfc_original_zstyles
+  unset _zfc_original_widgets
+  unset _zfc_original_bindings _zfc_original_compctls _zfc_added_fpath
+  unset _zfc_original_plugin_dir _zfc_original_plugin_dir_set
+  unset _zfc_original_os _zfc_original_os_set
+  unfunction zsh-fancy-completions_plugin_unload
+}

--- a/tests/unload.zsh
+++ b/tests/unload.zsh
@@ -1,0 +1,58 @@
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+
+typeset repo_dir=${0:A:h:h}
+typeset mode=${1:-preconfigured}
+typeset -gA Plugins
+typeset -gA ZI
+typeset -g PMSPEC=
+typeset -g TERM=xterm-256color
+typeset -g COMPLETION_WAITING_DOTS=1
+typeset test_cache=$(mktemp -d "${TMPDIR:-/tmp}/zfc-test-XXXXXX")
+trap 'rm -rf "$test_cache"' EXIT
+ZI[CACHE_DIR]=$test_cache
+autoload -Uz compinit
+compinit -i -d "$test_cache/.zcompdump"
+setopt err_return no_unset
+
+if [[ $mode == preconfigured ]]; then
+  typeset -g ZFC_OS=before-load
+  Plugins[ZF_COMPLETIONS]=before-load
+  unsetopt complete_in_word
+  setopt menu_complete
+  zstyle ':completion:*' cache-path before-load
+  bindkey -M emacs '^I' expand-or-complete
+else
+  unset ZFC_OS
+  unset 'Plugins[ZF_COMPLETIONS]'
+  zstyle -d ':completion:*' cache-path
+fi
+
+typeset before_fpath="${(j:\n:)fpath}"
+source "$repo_dir/zsh-fancy-completions.plugin.zsh"
+
+[[ $Plugins[ZF_COMPLETIONS] == "$repo_dir" ]]
+[[ $ZFC_OS != before-load ]]
+[[ -o complete_in_word ]]
+[[ ! -o menu_complete ]]
+[[ $(zstyle -L ':completion:*' cache-path) != *before-load* ]]
+
+zsh-fancy-completions_plugin_unload
+
+if [[ $mode == preconfigured ]]; then
+  [[ $Plugins[ZF_COMPLETIONS] == before-load ]]
+  [[ $ZFC_OS == before-load ]]
+  [[ ! -o complete_in_word ]]
+  [[ -o menu_complete ]]
+  [[ $(zstyle -L ':completion:*' cache-path) == *before-load* ]]
+else
+  (( ! ${+Plugins[ZF_COMPLETIONS]} ))
+  (( ! ${+ZFC_OS} ))
+  [[ -z $(zstyle -L ':completion:*' cache-path) ]]
+fi
+[[ "${(j:\n:)fpath}" == "$before_fpath" ]]
+[[ $(bindkey -M emacs '^I') == *expand-or-complete ]]
+(( ! ${+functions[zsh-fancy-completions_plugin_unload]} ))
+[[ -z ${(M)${(k)parameters}:#_zfc_*} ]]
+
+print "unload round trip ok: $mode"

--- a/zsh-fancy-completions.plugin.zsh
+++ b/zsh-fancy-completions.plugin.zsh
@@ -7,17 +7,24 @@
 
 # https://wiki.zshell.dev/community/zsh_plugin_standard#standard-plugins-hash
 typeset -gA Plugins
+source "${0:h}/lib/state.zsh"
+_zfc_capture_state
 Plugins[ZF_COMPLETIONS]="${0:h}"
 
 # https://wiki.zshell.dev/community/zsh_plugin_standard#funtions-directory
 if [[ $PMSPEC != *f* ]]; then
-  fpath+=( "${0:h}/functions" )
+  _zfc_add_fpath "${0:h}/functions"
 fi
 
 # Return if requirements are missing
 if [[ $TERM == 'dumb' ]]; then
   return 0
 else
-  source ${0:h}/lib/compatibility.zsh
-  source ${0:h}/lib/completion.zsh
+  source "${0:h}/lib/compatibility.zsh"
+  {
+    alias zstyle=_zfc_zstyle
+    source "${0:h}/lib/completion.zsh"
+  } always {
+    unalias zstyle
+  }
 fi


### PR DESCRIPTION
## Summary
- add a state helper that snapshots and restores plugin-owned options, `zstyle` entries, widgets, bindings, `compctl` entries, globals, and added `fpath` entries
- namespace the OS global as `ZFC_OS`
- quote sourced paths and guarantee temporary alias cleanup on load failure
- tolerate fresh shells without `ZI[CACHE_DIR]` or initialized `_comps`
- add default and preconfigured source-unload round-trip smoke tests

## Verification
- `zsh -n zsh-fancy-completions.plugin.zsh lib/*.zsh tests/*.zsh`
- `zsh -f -i -c 'source tests/unload.zsh default'`
- `zsh -f -i -c 'source tests/unload.zsh preconfigured'`
- `git diff --check`

Closes #43.