### PR TITLE
fix(completion): follow ssh_config Include directives for host completion

### DIFF
--- a/lib/completion.zsh
+++ b/lib/completion.zsh
@@ -159,26 +159,30 @@ zstyle -e ':completion:*:hosts' hosts '
   
   # SSH config hosts. Follow `Include` directives (e.g. the ~/.ssh/config.d/*
   # layout) which OpenSSH expands but a plain read of ~/.ssh/config would miss.
-  # Relative include paths resolve against ~/.ssh; ~ and globs are expanded, and
-  # already-seen files are skipped so include cycles cannot loop forever.
-  typeset -a _ssh_config_queue _ssh_config_files
+  # Each file is read exactly once and without forking: `$(<file)` is the
+  # builtin read, `${~pat}` handles the ~, ~user and glob forms of an include
+  # path, relative paths resolve against ~/.ssh, and a visited set keeps
+  # include cycles from looping.
+  typeset -a _ssh_config_queue _ssh_config_lines
+  typeset -A _ssh_config_seen
   typeset _ssh_config_file _ssh_config_inc _ssh_config_pat
   [[ -r $HOME/.ssh/config ]] && _ssh_config_queue=("$HOME/.ssh/config")
   while (( $#_ssh_config_queue )); do
     _ssh_config_file=$_ssh_config_queue[1]
     shift _ssh_config_queue
-    [[ -r $_ssh_config_file && -z ${_ssh_config_files[(r)$_ssh_config_file]} ]] || continue
-    _ssh_config_files+=("$_ssh_config_file")
-    for _ssh_config_inc in ${(M)${(f)"$(<"$_ssh_config_file")"}:#Include *}; do
-      for _ssh_config_pat in ${(z)${_ssh_config_inc#Include }}; do
-        _ssh_config_pat=${_ssh_config_pat/#\~/$HOME}
-        [[ $_ssh_config_pat == /* ]] || _ssh_config_pat=$HOME/.ssh/$_ssh_config_pat
+    if [[ ! -r $_ssh_config_file ]] || (( ${+_ssh_config_seen[$_ssh_config_file]} )); then
+      continue
+    fi
+    _ssh_config_seen[$_ssh_config_file]=1
+    _ssh_config_lines=(${(f)"$(<"$_ssh_config_file")"})
+    _ssh_config_hosts+=(${=${${${${(@M)_ssh_config_lines:#Host *}#Host }:#*\**}:#*\?*}})
+    for _ssh_config_inc in ${(@M)_ssh_config_lines:#Include *}; do
+      for _ssh_config_pat in ${(Q)${(z)${_ssh_config_inc#Include }}}; do
+        [[ $_ssh_config_pat == (/|\~)* ]] || _ssh_config_pat=$HOME/.ssh/$_ssh_config_pat
         _ssh_config_queue+=(${~_ssh_config_pat}(N))
       done
     done
   done
-  (( $#_ssh_config_files )) && \
-    _ssh_config_hosts=(${=${${${${(@M)${(f)"$(cat $_ssh_config_files 2>/dev/null)"}:#Host *}#Host }:#*\**}:#*\?*}})
   
   _hosts=($_ssh_hosts $_etc_hosts $_ssh_config_hosts)
   reply=($_hosts)

--- a/lib/completion.zsh
+++ b/lib/completion.zsh
@@ -157,9 +157,28 @@ zstyle -e ':completion:*:hosts' hosts '
   [[ -r /etc/hosts ]] && \
     _etc_hosts=(${=${(f)"$(<"/etc/hosts")"}%%\#*})
   
-  # SSH config hosts (only if file exists)
-  [[ -r $HOME/.ssh/config ]] && \
-    _ssh_config_hosts=(${=${${${${(@M)${(f)"$(<"$HOME/.ssh/config")"}:#Host *}#Host }:#*\**}:#*\?*}})
+  # SSH config hosts. Follow `Include` directives (e.g. the ~/.ssh/config.d/*
+  # layout) which OpenSSH expands but a plain read of ~/.ssh/config would miss.
+  # Relative include paths resolve against ~/.ssh; ~ and globs are expanded, and
+  # already-seen files are skipped so include cycles cannot loop forever.
+  typeset -a _ssh_config_queue _ssh_config_files
+  typeset _ssh_config_file _ssh_config_inc _ssh_config_pat
+  [[ -r $HOME/.ssh/config ]] && _ssh_config_queue=("$HOME/.ssh/config")
+  while (( $#_ssh_config_queue )); do
+    _ssh_config_file=$_ssh_config_queue[1]
+    shift _ssh_config_queue
+    [[ -r $_ssh_config_file && -z ${_ssh_config_files[(r)$_ssh_config_file]} ]] || continue
+    _ssh_config_files+=("$_ssh_config_file")
+    for _ssh_config_inc in ${(M)${(f)"$(<"$_ssh_config_file")"}:#Include *}; do
+      for _ssh_config_pat in ${(z)${_ssh_config_inc#Include }}; do
+        _ssh_config_pat=${_ssh_config_pat/#\~/$HOME}
+        [[ $_ssh_config_pat == /* ]] || _ssh_config_pat=$HOME/.ssh/$_ssh_config_pat
+        _ssh_config_queue+=(${~_ssh_config_pat}(N))
+      done
+    done
+  done
+  (( $#_ssh_config_files )) && \
+    _ssh_config_hosts=(${=${${${${(@M)${(f)"$(cat $_ssh_config_files 2>/dev/null)"}:#Host *}#Host }:#*\**}:#*\?*}})
   
   _hosts=($_ssh_hosts $_etc_hosts $_ssh_config_hosts)
   reply=($_hosts)

--- a/lib/completion.zsh
+++ b/lib/completion.zsh
@@ -179,7 +179,10 @@ zstyle -e ':completion:*:hosts' hosts '
     for _ssh_config_inc in ${(@M)_ssh_config_lines:#Include *}; do
       for _ssh_config_pat in ${(Q)${(z)${_ssh_config_inc#Include }}}; do
         [[ $_ssh_config_pat == (/|\~)* ]] || _ssh_config_pat=$HOME/.ssh/$_ssh_config_pat
-        _ssh_config_queue+=(${~_ssh_config_pat}(N))
+        # `-.` keeps only regular files: an extensionless pattern such as
+        # `config.d/*` can otherwise match a subdirectory, and reading one
+        # would print an error over the completion display.
+        _ssh_config_queue+=(${~_ssh_config_pat}(N-.))
       done
     done
   done

--- a/tests/hosts.zsh
+++ b/tests/hosts.zsh
@@ -64,6 +64,12 @@ EOF
 # An include cycle must terminate rather than loop forever.
 print 'Include ~/.ssh/config' >>"$test_home/.ssh/config.d/network.conf"
 
+# An extensionless include pattern can match a subdirectory. Reading one would
+# print an error over the completion display, so directories must be skipped.
+mkdir -p "$test_home/.ssh/extensionless/adir"
+print 'Host extensionless-host' >"$test_home/.ssh/extensionless/afile"
+print 'Include ~/.ssh/extensionless/*' >>"$test_home/.ssh/config"
+
 # Wildcard patterns are configuration, not hosts, and must not be offered.
 print -l '' 'Host *' '  ServerAliveInterval 60' >>"$test_home/.ssh/config"
 
@@ -72,12 +78,21 @@ typeset -g HOME=$test_home
 source "$repo_dir/zsh-fancy-completions.plugin.zsh"
 
 # `zstyle -a` on an `-e` style evaluates the code and returns its `reply`.
+# Resolution must stay silent: anything on stderr lands on the completion
+# display mid-keypress.
 typeset -a resolved
-zstyle -a ':completion:*:hosts' hosts resolved
+typeset stderr_file=$test_home/stderr
+zstyle -a ':completion:*:hosts' hosts resolved 2>"$stderr_file"
 
 typeset expected ok=1
+if [[ -s $stderr_file ]]; then
+  print "UNEXPECTED: host resolution wrote to stderr"
+  print -r -- "$(<"$stderr_file")"
+  ok=0
+fi
+
 for expected in direct-host included-host included-alias nested-host \
-  named-dir-host relative-host spaced-host; do
+  named-dir-host relative-host spaced-host extensionless-host; do
   if (( ! ${resolved[(Ie)$expected]} )); then
     print "MISSING: $expected"
     ok=0

--- a/tests/hosts.zsh
+++ b/tests/hosts.zsh
@@ -5,6 +5,14 @@
 # ~/.ssh/config, so Host aliases defined in included files (e.g. the common
 # ~/.ssh/config.d/*.conf layout) are offered for completion and host
 # highlighting, not just those written directly in ~/.ssh/config.
+#
+# Covers each include-path form OpenSSH accepts:
+#   ~/…      tilde-home
+#   ~name/…  named form — the same branch as `~user/…`, which a plain
+#            `${path/#\~/$HOME}` substitution would mangle into `$HOMEname/…`
+#   path     relative, resolved against ~/.ssh
+#   "…"      quoted, so paths may contain spaces
+# plus transitive includes (an included file including another).
 
 typeset repo_dir=${0:A:h:h}
 typeset -gA Plugins ZI
@@ -15,17 +23,49 @@ typeset test_home
 test_home=$(mktemp -d "${TMPDIR:-/tmp}/zfc-hosts-XXXXXX")
 trap 'rm -rf "$test_home"' EXIT
 
-mkdir -p "$test_home/.ssh/config.d"
+mkdir -p "$test_home/.ssh/config.d/nested" "$test_home/extra"
+
+# A named directory exercises the `~name/…` include form hermetically; a real
+# `~user/…` would resolve through the password database, outside $test_home.
+hash -d zfc_extra="$test_home/extra"
+
 cat >"$test_home/.ssh/config" <<'EOF'
 Include ~/.ssh/config.d/*.conf
+Include ~zfc_extra/*.conf
+Include relative.conf
+Include "spaced name.conf"
 
 Host direct-host
   HostName 203.0.113.10
 EOF
 cat >"$test_home/.ssh/config.d/network.conf" <<'EOF'
+Include ~/.ssh/config.d/nested/*.conf
+
 Host included-host included-alias
   HostName 198.51.100.20
 EOF
+cat >"$test_home/.ssh/config.d/nested/deep.conf" <<'EOF'
+Host nested-host
+  HostName 198.51.100.30
+EOF
+cat >"$test_home/extra/named.conf" <<'EOF'
+Host named-dir-host
+  HostName 198.51.100.40
+EOF
+cat >"$test_home/.ssh/relative.conf" <<'EOF'
+Host relative-host
+  HostName 198.51.100.50
+EOF
+cat >"$test_home/.ssh/spaced name.conf" <<'EOF'
+Host spaced-host
+  HostName 198.51.100.60
+EOF
+
+# An include cycle must terminate rather than loop forever.
+print 'Include ~/.ssh/config' >>"$test_home/.ssh/config.d/network.conf"
+
+# Wildcard patterns are configuration, not hosts, and must not be offered.
+print -l '' 'Host *' '  ServerAliveInterval 60' >>"$test_home/.ssh/config"
 
 typeset -g HOME=$test_home
 
@@ -36,12 +76,18 @@ typeset -a resolved
 zstyle -a ':completion:*:hosts' hosts resolved
 
 typeset expected ok=1
-for expected in direct-host included-host included-alias; do
-  if [[ -z ${resolved[(r)$expected]} ]]; then
+for expected in direct-host included-host included-alias nested-host \
+  named-dir-host relative-host spaced-host; do
+  if (( ! ${resolved[(Ie)$expected]} )); then
     print "MISSING: $expected"
     ok=0
   fi
 done
+
+if (( ${resolved[(Ie)\*]} )); then
+  print "UNEXPECTED: wildcard 'Host *' offered as a host"
+  ok=0
+fi
 
 if (( ok )); then
   print "hosts include-follow ok"

--- a/tests/hosts.zsh
+++ b/tests/hosts.zsh
@@ -1,0 +1,52 @@
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+#
+# Verify the ':completion:*:hosts' style follows `Include` directives in
+# ~/.ssh/config, so Host aliases defined in included files (e.g. the common
+# ~/.ssh/config.d/*.conf layout) are offered for completion and host
+# highlighting, not just those written directly in ~/.ssh/config.
+
+typeset repo_dir=${0:A:h:h}
+typeset -gA Plugins ZI
+typeset -g PMSPEC=
+typeset -g TERM=xterm-256color
+
+typeset test_home
+test_home=$(mktemp -d "${TMPDIR:-/tmp}/zfc-hosts-XXXXXX")
+trap 'rm -rf "$test_home"' EXIT
+
+mkdir -p "$test_home/.ssh/config.d"
+cat >"$test_home/.ssh/config" <<'EOF'
+Include ~/.ssh/config.d/*.conf
+
+Host direct-host
+  HostName 203.0.113.10
+EOF
+cat >"$test_home/.ssh/config.d/network.conf" <<'EOF'
+Host included-host included-alias
+  HostName 198.51.100.20
+EOF
+
+typeset -g HOME=$test_home
+
+source "$repo_dir/zsh-fancy-completions.plugin.zsh"
+
+# `zstyle -a` on an `-e` style evaluates the code and returns its `reply`.
+typeset -a resolved
+zstyle -a ':completion:*:hosts' hosts resolved
+
+typeset expected ok=1
+for expected in direct-host included-host included-alias; do
+  if [[ -z ${resolved[(r)$expected]} ]]; then
+    print "MISSING: $expected"
+    ok=0
+  fi
+done
+
+if (( ok )); then
+  print "hosts include-follow ok"
+else
+  print "hosts include-follow FAILED"
+  print "resolved: ${resolved}"
+  exit 1
+fi


### PR DESCRIPTION
## Problem

The `:completion:*:hosts` style parses `~/.ssh/config` directly. OpenSSH itself expands `Include` directives, but a plain file read does not — so `Host` aliases defined in included files (e.g. the common `~/.ssh/config.d/*.conf` layout) never reach completion or F-Sy-H's ssh host highlighting. Only hosts written into `~/.ssh/config` itself were offered.

Concretely: with `Include ~/.ssh/config.d/*.conf` in the main config and `Host myhost` in `config.d/network.conf`, `ssh myhost` was neither completed nor highlighted as a known host, while a host in `/etc/hosts` (e.g. `core.internal`) was.

## Fix

Within the existing `zstyle -e ':completion:*:hosts'` block, walk `Include` directives starting from `~/.ssh/config`:

- Resolve relative include paths against `~/.ssh`, expand `~` and globs.
- Skip already-seen files with a visited-guard so include cycles cannot loop.
- Host extraction is unchanged and now runs over the full resolved file set.

Kept dynamic (`zstyle -e`) and default-glob only (no `EXTENDED_GLOB` / `(#i)`), so `/etc/hosts` and `known_hosts` completion is unaffected, and `Include `/`Host ` matching stays case-sensitive like the original.

## Tests

Adds `tests/hosts.zsh`: a fixture `~/.ssh/config` that `Include`s a `config.d/*.conf`, then asserts both the direct host and the included aliases appear in `:completion:*:hosts` (`zstyle -a` evaluates the `-e` code).

Verified locally:

- `tests/hosts.zsh` — RED against the unmodified plugin (included aliases missing, direct host present), GREEN after the fix.
- `tests/unload.zsh` — passes both `preconfigured` and `clean` modes (no new `_zfc_*` state; unload contract intact).
- `zsh -n lib/completion.zsh` and `zcompile lib/completion.zsh` — pass (CI gates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)