### PR TITLE
ci(workflows): gate lib/ and run the test suite

### DIFF
--- a/.github/workflows/zsh-checks.yml
+++ b/.github/workflows/zsh-checks.yml
@@ -79,6 +79,6 @@ jobs:
             setopt err_exit
             for t in tests/*.zsh; do
               print -r -- "== $t"
-              zsh "$t"
+              zsh -f "$t"
             done
           '

--- a/.github/workflows/zsh-checks.yml
+++ b/.github/workflows/zsh-checks.yml
@@ -1,20 +1,23 @@
 ---
-name: "✅ Zsh"
+name: "Zsh Checks"
 on:
   push:
     branches: [main]
     tags: ["v*.*.*"]
     paths:
-      - "*.zsh"
-      - "functions/.*"
+      - "**/*.zsh"
+      - "functions/**"
+      - ".github/workflows/zsh-checks.yml"
   pull_request:
     branches: [main]
     paths:
-      - "*.zsh"
-      - "functions/.*"
+      - "**/*.zsh"
+      - "functions/**"
+      - ".github/workflows/zsh-checks.yml"
   workflow_dispatch: {}
 
-permissions: read-all
+permissions:
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -31,7 +34,10 @@ jobs:
       - name: "Set matrix output"
         id: set-matrix
         run: |
-          MATRIX="$(find . -type d -name 'doc' -prune -o -type f \( -iname '*.zsh' -o -iname '.completion-*' \) -print | jq -ncR '{"include": [{"file": inputs}]}')"
+          MATRIX="$(find . -path ./.git -prune -o -path ./.trunk -prune -o \
+            -type d -name 'doc' -prune -o \
+            \( -type f -name '*.zsh' -o -type f -path './functions/*' \) -print \
+            | sort | jq -ncR '{"include": [{"file": inputs}]}')"
           echo "files=${MATRIX}" >> $GITHUB_OUTPUT
 
   zsh-n:
@@ -56,3 +62,23 @@ jobs:
         run: |
           zsh -fc "zcompile ${ZSH_FILE}"; rc=$?
           ls -al "${ZSH_FILE}.zwc"; exit "$rc"
+
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: ⤵️ Check out code from GitHub
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: "⚡ Install dependencies"
+        run: sudo apt update && sudo apt-get install -yq zsh
+      # Each tests/*.zsh is a hermetic script that needs no arguments and exits
+      # non-zero on failure, so the suite is whatever the directory holds and
+      # new test files gate automatically.
+      - name: "🧪 Run test suite"
+        run: |
+          zsh -f -c '
+            setopt err_exit
+            for t in tests/*.zsh; do
+              print -r -- "== $t"
+              zsh "$t"
+            done
+          '

--- a/tests/unload.zsh
+++ b/tests/unload.zsh
@@ -9,7 +9,10 @@ typeset repo_dir=${0:A:h:h}
 # is the whole contract — that is how CI invokes every tests/*.zsh.
 if (( ! $# )); then
   for mode in preconfigured clean; do
-    zsh "${0:A}" "$mode" || exit 1
+    # -f keeps the nested run hermetic: without it a user's ~/.zshenv can set
+    # options this test asserts on. $? rather than a literal so a mode's real
+    # exit status reaches CI instead of a flattened 1.
+    zsh -f "${0:A}" "$mode" || exit $?
   done
   exit 0
 fi

--- a/tests/unload.zsh
+++ b/tests/unload.zsh
@@ -2,7 +2,19 @@
 # vim: ft=zsh sw=2 ts=2 et
 
 typeset repo_dir=${0:A:h:h}
-typeset mode=${1:-preconfigured}
+
+# Both modes matter: `preconfigured` proves prior user settings are restored,
+# `clean` proves nothing is left behind when there was nothing to restore.
+# With no argument, run each in a fresh shell so a bare `zsh tests/unload.zsh`
+# is the whole contract — that is how CI invokes every tests/*.zsh.
+if (( ! $# )); then
+  for mode in preconfigured clean; do
+    zsh "${0:A}" "$mode" || exit 1
+  done
+  exit 0
+fi
+
+typeset mode=$1
 typeset -gA Plugins
 typeset -gA ZI
 typeset -g PMSPEC=


### PR DESCRIPTION
Closes #46.

## Problem

The only Zsh-aware workflow in this repo never ran for the code it was meant to guard. Its path filter was top-level-glob only:

```yaml
paths:
  - "*.zsh"
  - "functions/.*"
```

`*.zsh` does not match `lib/completion.zsh`. Essentially all plugin logic lives under `lib/`, so every change there merged with no Zsh check at all — including #44 and, had it not been noticed, #45.

Two further gaps:

- The matrix generator selected `functions/` entries by literal prefix (`-iname '.completion-*'`), catching one of the five autoloaded function files and silently skipping `.complete_menu`, `.expand-or-complete-with-dots`, `.force_rehash`, and `.man_glob`.
- Nothing executed `tests/unload.zsh`, so the plugin-standard unload contract was unverified on every PR despite the test existing and passing.

Note: the original report claimed `functions/` was empty and its filter broken. That was wrong — the five files are dotfiles, which is why `ls` looked empty, and `functions/.*` matched them fine. Corrected in [a comment on #46](https://github.com/z-shell/zsh-fancy-completions/issues/46#issuecomment-5035873349); the matrix-generator gap above is the real second finding.

## Changes

- Path filters widened to `**/*.zsh` and `functions/**`, plus the workflow file itself.
- Matrix generated from all `*.zsh` plus every file under `functions/`, pruning `.git` and `.trunk`. **Coverage: 7 files → 10.**
- New `tests` job runs each `tests/*.zsh`, failing the build on non-zero exit.
- `tests/unload.zsh` runs both `preconfigured` and `clean` modes when given no argument, so every test file is a bare zero-argument invocation. Test files added later gate automatically with no workflow change.
- `zsh-n.yml` → `zsh-checks.yml`, `"✅ Zsh"` → `"Zsh Checks"` per ADR-0005 — the workflow is no longer only `zsh -n`.
- `permissions: read-all` → `contents: read` per the ADR-0009 baseline.

## Verification

Run locally:

- Suite green: `zsh tests/unload.zsh` passes both modes.
- **Suite can fail:** an injected `exit 3` test file propagates non-zero through the loop (`loop exit=3`). A runner that cannot go red is worthless, so this was checked explicitly.
- Matrix expression verified against the working tree — emits all 10 Zsh sources; all 10 pass `zsh -n` today.
- **#45 simulated as merged** — `tests/hosts.zsh` plus its `lib/completion.zsh` applied on top of this branch, suite green. The glob picks the new test up with no workflow change, so this does not conflict with #45 in either direction.
- Workflow YAML parses; `jobs: [zsh-matrix, zsh-n, tests]`.

No branch-protection contexts are configured on `main`, so renaming the workflow file breaks no required check.

## Follow-ups filed

- #48 — convert `tests/` to ZUnit, the class-3 form expected by ADR-0009.
- #49 — repeatable benchmark for host resolution, supporting #47. Deliberately **not** a CI gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)