### PR TITLE
fix: preserve completion expansion arguments

### DIFF
--- a/functions/.man_glob
+++ b/functions/.man_glob
@@ -1,6 +1,8 @@
 # -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
 # vim: ft=zsh sw=2 ts=2 et
 
+builtin emulate -L zsh
+
 typeset -a a
 read -cA a
 

--- a/lib/completion.zsh
+++ b/lib/completion.zsh
@@ -107,7 +107,7 @@ zstyle ':completion:*:history-words' menu yes
 
 # Environmental Variables
 if (( ${+_comps} )); then
-  zstyle ':completion::*:(-command-|export):*' fake-parameters ${${${_comps[(I)-value-*]#*,}%%,*}:#-*-}
+  zstyle ':completion::*:(-command-|export):*' fake-parameters "${(@)${${_comps[(I)-value-*]#*,}%%,*}:#-*-}"
 fi
 
 # Complete . and .. special directories
@@ -134,7 +134,7 @@ zstyle ':completion:*:*:mocp:*' file-patterns '*.(wav|WAV|mp3|MP3|ogg|OGG|flac):
 # Mutt
 if [[ -r "$HOME/.mutt/aliases" ]]; then
   zstyle ':completion:*:*:mutt:*' menu yes select
-  zstyle ':completion:*:mutt:*' users ${${${(f)"$(<"$HOME/.mutt/aliases")"}#alias[[:space:]]}%%[[:space:]]*}
+  zstyle ':completion:*:mutt:*' users "${(@)${${(f)"$(<"$HOME/.mutt/aliases")"}#alias[[:space:]]}%%[[:space:]]*}"
 fi
 
 # Populate hostname completion.


### PR DESCRIPTION
Closes #51.

## Summary
- preserve intended argument boundaries in completion expansions
- localize .man_glob function option changes

## Verification
- `find functions lib -type f -print0 | xargs -0 zsh -f -n`
- `zsh tests/hosts.zsh && zsh tests/unload.zsh`
- included in the strict 19-file corpus with zero errors and zero warnings